### PR TITLE
README: remove aludel mini from list of supported boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ images](https://github.com/golioth/reference-design-can-asset-tracker/releases).
 
 - Nordic nRF9160-DK
 - Golioth Aludel Elixir
-- Golioth Aludel Mini
 
 ### Additional Sensors/Components
 


### PR DESCRIPTION
support for the Aludel Mini was removed in the latest release.